### PR TITLE
Forced restart scanning

### DIFF
--- a/custom_components/govee_ble_hci/sensor.py
+++ b/custom_components/govee_ble_hci/sensor.py
@@ -86,6 +86,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
 
     govee_devices: List[BLE_HT_data] = []  # Data objects of configured devices
     sensors_by_mac = {}  # HomeAssistant sensors by MAC address
+    adapter = None
 
     def handle_meta_event(hci_packet) -> None:
         """Handle recieved BLE data."""
@@ -182,6 +183,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
     def update_ble_loop(now) -> None:
         """Lookup Bluetooth LE devices and update status."""
         _LOGGER.debug("update_ble_loop called")
+        adapter.start_scanning()
 
         try:
             # Time to make the dounuts


### PR DESCRIPTION
Some BLE devices will stop scanning after a period of time.  Specifically, the LM1010 (https://www.amazon.com/gp/product/B07N1XJ5JH/) has this issue.
Restarting the scanning function during each update_ble_loop has not had any negative effect for the past few days.

Perhaps a config item to enable "Forced scan restart" would be helpful if other BLE adapters are negatively impacted.