### PR TITLE
Add period configuration to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Specify the sensor platform `govee_ble_hci` and a list of devices with unique MA
 ```
 sensor:
   - platform: govee_ble_hci
+    period: 300
     govee_devices:
       - mac: "A4:C1:38:A1:A2:A3"
         name: Bedroom


### PR DESCRIPTION
It wasn't clear to me whether this was a device or platform-specific option.