### PR TITLE
Add support for the GoVee H5179 BLE/Wifi combo sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A custom component for [Home Assistant](https://www.home-assistant.io) that list
 * Govee H5101
 * [Govee H5102](https://www.amazon.com/gp/product/B087313N8F/)
 * [Govee H5177](https://www.amazon.com/gp/product/B08C9VYMHY)
+* [Govee H5179](https://www.amazon.com/gp/product/B0872ZWV8X)  (BLE only, Wi-Fi interface not supported))
 
 ## Installation
 

--- a/custom_components/govee_ble_hci/govee_advertisement.py
+++ b/custom_components/govee_ble_hci/govee_advertisement.py
@@ -114,10 +114,10 @@ class GoveeAdvertisement:
                 self.battery = int(self.mfg_data[7])
                 self.model = "Govee H5101/H5102"
             elif self.check_is_gvh5179():
-                temp, humidity, battery = struct.unpack_from("<HHB", self.mfg_data, 6)
+                temp, hum, batt = struct.unpack_from("<HHB", self.mfg_data, 6)
                 self.temperature = float(twos_complement(temp) / 100.0)
-                self.humidity = float(humidity / 100.0)
-                self.battery = int(battery)
+                self.humidity = float(hum / 100.0)
+                self.battery = int(batt)
                 self.packet = 1
                 self.model = "Govee H5179"
             elif self.check_is_gvh5074() or self.check_is_gvh5051():

--- a/custom_components/govee_ble_hci/govee_advertisement.py
+++ b/custom_components/govee_ble_hci/govee_advertisement.py
@@ -1,6 +1,7 @@
 """Govee thermometer/hygrometer BLE advertisement parser."""
 from typing import Optional
 import logging
+import struct
 
 from bleson.core.hci.constants import (  # type: ignore
     GAP_FLAGS,
@@ -112,6 +113,13 @@ class GoveeAdvertisement:
                 self.humidity = float((self.packet % 1000) / 10)
                 self.battery = int(self.mfg_data[7])
                 self.model = "Govee H5101/H5102"
+            elif self.check_is_gvh5179():
+                temp, humidity, battery = struct.unpack_from("<HHB", self.mfg_data, 6)
+                self.temperature = float(twos_complement(temp) / 100.0)
+                self.humidity = float(humidity / 100.0)
+                self.battery = int(battery)
+                self.packet = 1
+                self.model = "Govee H5179"
             elif self.check_is_gvh5074() or self.check_is_gvh5051():
                 mfg_data_5074 = hex_string(self.mfg_data[3:7]).replace(" ", "")
                 temp_lsb = mfg_data_5074[2:4] + mfg_data_5074[0:2]
@@ -141,6 +149,10 @@ class GoveeAdvertisement:
     def check_is_gvh5051(self) -> bool:
         """Check if mfg data is that of Govee H5051."""
         return self._mfg_data_check(11, 6)
+
+    def check_is_gvh5179(self) -> bool:
+        """Check if mfg data is that of Govee H5179."""
+        return self._mfg_data_check(11, 6) and self._mfg_data_id_check("0188")
 
     def _mfg_data_check(self, data_length: int, flags: int) -> bool:
         """Check if mfg data is of a certain length with the correct flag."""


### PR DESCRIPTION
I bought one of the new (newish?) GoVee H5179 BLE/Wifi combo sensor from Amazon a couple weeks ago.
https://www.amazon.com/gp/product/B0872ZWV8X

It supports retrieving data over Wi-Fi, as well as the standard BLE interface that most of the sensors support.

This patch/pull request just brings in support for the new sensor over BLE.
(Obviously Wi-Fi is not supported)

I tested this at room temperature, and then moved the sensor to my Freezer that sits at about 0 F.
I was able to watch it slowly crawl downwards from about 70 to 0 F. 
Works well, even through the walls of the freezer.
