### PR TITLE
Lower TMIN in const.py to accommodate freezer temps

### DIFF
--- a/custom_components/govee_ble_hci/const.py
+++ b/custom_components/govee_ble_hci/const.py
@@ -25,7 +25,7 @@ DEFAULT_HCI_DEVICE = "hci0"
 """Fixed constants."""
 
 # Sensor measurement limits to exclude erroneous spikes from the results
-CONF_TMIN = -20.0
+CONF_TMIN = -30.0
 CONF_TMAX = 60.0
 CONF_HMIN = 0.0
 CONF_HMAX = 99.9


### PR DESCRIPTION
I've got a sensor in my freezer (can get down to -15F or so) and the sensor is showing up as 'unknown' below -4F.